### PR TITLE
fix: sqlite 下 insert ignore 应当为  insert or ignore

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -156,6 +156,20 @@ module.exports = class SQLiteParser extends Parser {
     if (keywords.indexOf(keyUpperCase) > -1 || /^\d/.test(key)) return `"${key}"`;
     return key;
   }
+
+  /**
+   * build insert sql
+   * @param {Object} options
+   */
+   buildInsertSql(options) {
+    const sql = super.buildInsertSql(options);
+
+    // FIX `INSERT IGNORE` generated in think-model-abstract
+    // For sqlite, the equivalent syntax for `insert ignore` is `insert or ignore`
+    // SEE https://www.sqlite.org/lang_insert.html
+    return sql.replace(/^INSERT IGNORE/,'INSERT OR IGNORE');
+  }
+
   /**
    * escape string
    * @param  {String} str []


### PR DESCRIPTION

For sqlite, the equivalent syntax for `insert ignore` is `insert or ignore` (https://www.sqlite.org/lang_insert.html).


**Reference: [think-model-abstract/lib/parser.js](https://github.com/thinkjs/think-model-abstract/blob/master/lib/parser.js#L623)**
