### PR TITLE
[bugfix] Default values surrounded by quotes and issue with "DEFAULT NULL" thinkjs/thinkjs#1721

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -72,7 +72,7 @@ module.exports = class MysqlSchema extends Schema {
             name: item.name,
             type: item.type,
             required: !!item.notnull,
-            default: item.dflt_value || '',
+            default: '',
             primary: !!item.pk,
             unique: item.unique,
             autoIncrement: false


### PR DESCRIPTION
This pull request attempts to fix thinkjs/thinkjs#1721 (and an issue with "DEFAULT NULL")

## DESC

I use a SQLite database. I create the following table:

```sql
CREATE TABLE `post` (
  `id` integer NOT NULL PRIMARY KEY AUTOINCREMENT,
  `title` text NOT NULL,
  `content` text NOT NULL DEFAULT 'abc',
  `subtitle` text DEFAULT NULL
);
```

**Expected behavior**: When I add a `post` to the database without specifying its `content` and `subtitle` values, the default value for `content` should be the string `abc`, and for `subtitle` should be null.

**Actual behavior**: Instead, the default value for `content` is surrounded by two single quotes (`'abc'`). The value for `subtitle` is the string `NULL`, as shown by the log:

```
[INFO] - SQL: INSERT INTO post (title,content,subtitle) VALUES ('hello','''abc''','NULL')
```

### ENV

OS Platform: Ubuntu **22.04**

Node.js Version: **16.20.1**

ThinkJS Version: **3.2.15** (`think-model`: 1.5.4, `think-model-sqlite`: 1.3.1)

### code

```js
// Creates a post, but unexpectedly sets the `content` value to `'abc'` and `subtitle` to the string `NULL`
const id = await this.model('post')
  .add({ title: 'hello' });

const post = await this.model('post')
  .where({ id })
  .find();

console.log(post);
// { id: 1, title: 'hello', content: "'abc'", subtitle: 'NULL' }
```

## how to reproduce

I attached a project zip to this issue.

[thinkjs-model-sqlite-bugfix.zip](https://github.com/thinkjs/think-model-sqlite/files/12226801/thinkjs-model-sqlite-bugfix.zip)

To reproduce the bug, create the SQLite database:

```bash
mkdir -p runtime
rm -f runtime/bugfix.sqlite
sqlite3 runtime/bugfix.sqlite '.read table.sql'
```

Run the server:

```bash
npm install
npm start
```

Access `http://localhost:8360/`

### more description

Running `PRAGMA table_info( post )` in SQLite shows:

```
0|id|INTEGER|1||1
1|title|TEXT|1||0
2|content|TEXT|1|'abc'|0
3|subtitle|TEXT|0|NULL|0
```

This is where the `'abc'` and `NULL` values come from.

The values are assigned here: https://github.com/thinkjs/think-model-sqlite/blob/d6f52a6629b069c6d47f4700c6ad54bed5432421/lib/schema.js#L75

They are later passed to `_parseItemSchema()` but the original value remains.

### fix

Ignore `item.dflt_value` and set `item.default` to the empty string `''`, as done in [think-model-mysql](https://github.com/thinkjs/think-model-mysql/blob/2302ea5ca31457dba8320fad2ee043d77a52b306/lib/schema.js#L66) and [think-model-postgresql](https://github.com/thinkjs/think-model-postgresql/blob/221817eb7cc2364ec2c639c4aa533535eba5c8b8/lib/schema.js#L66).

It results in letting the native SQLite driver set the default value, which might be a more desirable behavior, and avoids parsing the SQLite syntax.
